### PR TITLE
add NO_BACK_COMPAT define to avoid HAVE_AT

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.59)
-AC_INIT([libeio], [1.0.1])
+AC_INIT([libeio], [1.0.2])
 AC_CONFIG_SRCDIR([eio.h])
 AC_CONFIG_HEADERS([config.h])
 AM_INIT_AUTOMAKE

--- a/eio.c
+++ b/eio.c
@@ -378,7 +378,7 @@ static void eio_destroy (eio_req *req);
 
 struct etp_tmpbuf;
 
-#if _POSIX_VERSION >= 200809L
+#if _POSIX_VERSION >= 200809L && NO_BACK_COMPAT
   #define HAVE_AT 1
   #define WD2FD(wd) ((wd) ? (wd)->fd : AT_FDCWD)
 #else


### PR DESCRIPTION
This fixes https://github.com/rapid7/metasploit-framework/issues/14787